### PR TITLE
Add support for symbolic links

### DIFF
--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -121,6 +121,25 @@ Returns ``True`` if the path points to a Bucket or a key prefix,
 ``False`` is also returned if the path doesn’t exist.
 Other errors (such as permission errors) are propagated.
 
+
+S3Path.is_symlink()
+^^^^^^^^^^^^^^^^^^^
+
+Returns ``False`` if the path points to a Bucket or key prefix by checking ``path.is_dir()``,
+returns ``False`` if the path does not exist.
+
+Returns ``True`` if the path is a 0-byte file with a value set for the header 
+``x-amz-website-redirect-location``.
+
+S3Path.symlink_to(target, target_is_directory=False)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create a new symbolic link by writing a 0-byte file to the current path with the
+custom header ``x-amz-website-redirect-location`` using a value of ``target``. The second
+parameter, ``target_is_directory``, is present for API compatibility with ``pathlib.Path``
+but is ignored during evaluation.
+
+
 S3Path.is_file()
 ^^^^^^^^^^^^^^^^
 
@@ -134,12 +153,6 @@ S3Path.is_mount()
 ^^^^^^^^^^^^^^^^^
 
 AWS S3 Service doesn't have mounting feature,
-There for this method will always return ``False``
-
-S3Path.is_symlink()
-^^^^^^^^^^^^^^^^^^^
-
-AWS S3 Service doesn't have symlink feature,
 There for this method will always return ``False``
 
 S3Path.is_socket()
@@ -445,7 +458,6 @@ Here is a list of all unsupported methods:
 - S3Path.is_char_device()
 - S3Path.lstat()
 - S3Path.resolve()
-- S3Path.symlink_to(target, target_is_directory=False)
 
 
 .. _pathlib : https://docs.python.org/3/library/pathlib.html

--- a/s3path.py
+++ b/s3path.py
@@ -157,7 +157,7 @@ class _S3Accessor(_Accessor):
             try:
                 base_summary.wait_until_exists()
             except WaiterError:
-                raise FileNotFoundError("/{0}/{1}".format(bucket, key)
+                raise FileNotFoundError("/{0}/{1}".format(bucket, key))
         elif not symlink_target and not (
             base_summary.meta or getattr(base_summary.meta, "get", None)
         ):

--- a/s3path.py
+++ b/s3path.py
@@ -220,6 +220,11 @@ class _S3Accessor(_Accessor):
         object_inst = object_summary.Object()
         redirect_location = None
         try:
+            if path.exists() and path.is_dir():
+                return False
+        except ClientError:
+            raise FileNotFoundError(str(path))
+        try:
             redirect_location = object_inst.website_redirect_location
         except ClientError:
             self._wait_for_object_summary(object_summary)

--- a/s3path.py
+++ b/s3path.py
@@ -157,7 +157,7 @@ class _S3Accessor(_Accessor):
             try:
                 base_summary.wait_until_exists()
             except WaiterError:
-                raise FileNotFoundError(f"/{bucket}/{key}")
+                raise FileNotFoundError("/{0}/{1}".format(bucket, key)
         elif not symlink_target and not (
             base_summary.meta or getattr(base_summary.meta, "get", None)
         ):

--- a/tests/test_not_supported.py
+++ b/tests/test_not_supported.py
@@ -40,10 +40,6 @@ def test_is_mount():
     assert not S3Path('/fake-bucket/fake-key').is_mount()
 
 
-def test_is_symlink():
-    assert not S3Path('/fake-bucket/fake-key').is_symlink()
-
-
 def test_is_socket():
     assert not S3Path('/fake-bucket/fake-key').is_socket()
 
@@ -75,8 +71,3 @@ def test_resolve():
     with pytest.raises(NotImplementedError):
         path.resolve()
 
-
-def test_symlink_to():
-    path = S3Path('/fake-bucket/fake-key')
-    with pytest.raises(NotImplementedError):
-        path.symlink_to('file_name')

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -540,5 +540,5 @@ def test_symlink(s3_mock):
     assert new_path.is_symlink() is True
     assert new_path.read_bytes() == data
     assert not path.is_symlink()
-    with pytest.raises(ClientError):
+    with pytest.raises(FileNotFoundError):
         assert not S3Path('/fake-bucket/fake-key').is_symlink()


### PR DESCRIPTION
- Add support for symbolic links in S3
- Check for symlinks during `read` and directory traversal
- Add `S3Path.is_symlink`, `S3Path.symlink_to`, `_S3Accessor.symlink`,
  and `_S3Accessor.is_symlink`
- Refactor `ObjectSummary` instantiation to a separate method to allow
  for a new `follow_symlinks` argument to be passed, which, if True,
  results in the final non-symlink `ObjectSummary` instance being
  returned
- Fixes #35

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>