### PR TITLE
Import stat_result from os instead of posix

### DIFF
--- a/s3path.py
+++ b/s3path.py
@@ -1,7 +1,7 @@
 """
 s3path provides a Pythonic API to S3 by wrapping boto3 with pathlib interface
 """
-from posix import stat_result
+from os import stat_result
 from contextlib import suppress
 from collections import namedtuple
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
This makes it operating system independent, as at the moment, this library doesn't work under Windows.

Nothing changes, as it was used from `os` already.
```python
>>> from posix import stat_result
>>> stat_result
<class 'os.stat_result'>
```