### PR TITLE
Allow passing of chunk size to read

### DIFF
--- a/s3path.py
+++ b/s3path.py
@@ -873,7 +873,7 @@ class S3KeyReadableFileObject(RawIOBase):
 
     @readable_check
     def read(self, *args, **kwargs):
-        return self._string_parser(self._streaming_body.read())
+        return self._string_parser(self._streaming_body.read(*args, **kwargs))
 
     @readable_check
     def readlines(self, *args, **kwargs):


### PR DESCRIPTION
Closes #47 

This solves the problem, at least for my case, where I cannot pass the chunk size to the `read([size])` method.

Be warned that I'm not so familiar with the details of the botocore API, so the `*args, **kwargs` may or may not be superfluous. A potential alternative solution could look something like

```python
def read(self, size=None):
    return self._string_parser(self._streaming_body.read(size))
```