### PR TITLE
fix: Fixes S3KeyReadableFileObject line iteration

### DIFF
--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -203,6 +203,49 @@ def test_is_file(s3_mock):
     assert S3Path('/test-bucket/build/lib/pathlib.py').is_file()
 
 
+def test_read_line(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    object_summary = s3.ObjectSummary('test-bucket', 'directory/Test.test')
+    object_summary.put(Body=b'test data\ntest data')
+
+    with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
+        assert fp.readline() == "test data"
+        assert fp.readline() == "test data"
+        assert fp.readline() == ""
+
+
+def test_read_lines(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    object_summary = s3.ObjectSummary('test-bucket', 'directory/Test.test')
+    object_summary.put(Body=b'test data\ntest data')
+
+    with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
+        assert len(fp.readlines()) == 2
+
+
+def test_read_lines_hint(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    object_summary = s3.ObjectSummary('test-bucket', 'directory/Test.test')
+    object_summary.put(Body=b'test data\ntest data')
+
+    with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
+        assert len(fp.readlines(1)) == 1
+
+
+def test_iter_lines(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    object_summary = s3.ObjectSummary('test-bucket', 'directory/Test.test')
+    object_summary.put(Body=b'test data\ntest data')
+
+    with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
+        for line in fp:
+            assert line == "test data"
+
+
 def test_iterdir(s3_mock):
     s3 = boto3.resource('s3')
     s3.create_bucket(Bucket='test-bucket')


### PR DESCRIPTION
This PR aims to fix the `S3KeyReadableFileObject` line iteration.

There were a few issues:
* Everytime `readline` was called a new generator was created from `_streaming_body.iter_lines`
* The `__next__` method was calling `readline` and this method never raises `StopIteration`
* `readlines` was iterating over `readline` that  never raises `StopIteration`

Now the iterator is kept and reused so we can start consuming the file from one method and then continue from another.
We can also iterate over `S3KeyReadableFileObject` as it will read the lines and stop when it should.

See #53 