### PR TITLE
fix: Fixes writelines method of S3KeyWritableFileObject

### DIFF
--- a/s3path.py
+++ b/s3path.py
@@ -800,7 +800,13 @@ class S3KeyWritableFileObject(RawIOBase):
         )
 
     def writelines(self, lines):
-        self.write(self._string_parser('\n').join(self._string_parser(line) for line in lines))
+        if not lines:
+            return
+        if isinstance(lines[0], bytes):
+            joined = b"".join(lines)
+        else:
+            joined = "".join(lines)
+        self.write(joined)
 
     def readable(self):
         return False

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -203,6 +203,18 @@ def test_is_file(s3_mock):
     assert S3Path('/test-bucket/build/lib/pathlib.py').is_file()
 
 
+def test_write_lines(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+
+    path = S3Path('/test-bucket/directory/Test.test')
+    with path.open("w") as fp:
+        fp.writelines(["line 1\n", "line 2\n"])
+
+    res = path.read_text().splitlines()
+    assert len(res) == 2
+
+
 def test_iterdir(s3_mock):
     s3 = boto3.resource('s3')
     s3.create_bucket(Bucket='test-bucket')


### PR DESCRIPTION
To be compliant with the base writelines method the new line character should not be added.

From the documentation https://docs.python.org/2/library/stdtypes.html#file.writelines :

> The name is intended to match readlines(); writelines() does not add line separators.

There was also an issue where the double call to `_string_parser` (once in `writlines` and then in `write`) was raising an error:

>  TypeError: a bytes-like object is required, not 'str'

See #52