### PR TITLE
feat: Keep newline characters in readline and readlines

### DIFF
--- a/s3path.py
+++ b/s3path.py
@@ -875,7 +875,7 @@ class S3KeyReadableFileObject(RawIOBase):
     def _line_iterator(self):
         if not self._streaming_line_iterator:
             self._streaming_line_iterator = self._streaming_body.iter_lines(
-                chunk_size=self.buffering
+                chunk_size=self.buffering, keepends=True
             )
         return self._streaming_line_iterator
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author='Lior Mizrahi',
     author_email='li.mizr@gmail.com',
     py_modules=['s3path'],
-    install_requires=['boto3'],
+    install_requires=['boto3>=1.16.35'],
     license='Apache 2.0',
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -210,7 +210,7 @@ def test_read_line(s3_mock):
     object_summary.put(Body=b'test data\ntest data')
 
     with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
-        assert fp.readline() == "test data"
+        assert fp.readline() == "test data\n"
         assert fp.readline() == "test data"
         assert fp.readline() == ""
 
@@ -239,11 +239,11 @@ def test_iter_lines(s3_mock):
     s3 = boto3.resource('s3')
     s3.create_bucket(Bucket='test-bucket')
     object_summary = s3.ObjectSummary('test-bucket', 'directory/Test.test')
-    object_summary.put(Body=b'test data\ntest data')
+    object_summary.put(Body=b'test data\ntest data\n')
 
     with S3Path('/test-bucket/directory/Test.test').open("r") as fp:
         for line in fp:
-            assert line == "test data"
+            assert line == "test data\n"
 
 
 def test_write_lines(s3_mock):


### PR DESCRIPTION
This PR make S3Path respects the file interface concerning the newline characters in the `readlines` and `readline` methods.

> f.readline() reads a single line from the file; a newline character (\n) is left at the end of the string, and is only omitted on the last line of the file if the file doesn’t end in a newline.

See https://docs.python.org/3/tutorial/inputoutput.html#methods-of-file-objects

Parent issue: #56

We have to be aware that this feature is creating a **breaking change** since it modifies the output of `readlines` and `readline`.

I think this is for the best because it will get the project closer to the interface it tries to imitate.
