### PR TITLE
Don't encode as URI for smart_open

### DIFF
--- a/s3path.py
+++ b/s3path.py
@@ -198,7 +198,7 @@ class _S3Accessor(_Accessor):
         resource, config = self.configuration_map.get_configuration(path)
 
         smart_open_kwargs = {
-            'uri': path.as_uri(),
+            'uri': "s3:/" + str(path),
             'mode': mode,
             'buffering': buffering,
             'encoding': encoding,


### PR DESCRIPTION
This should resolve #77 for most cases.

See the discussion in #77 for further thoughts. This isn't intended to be a final fix, since I think we need to decide what is the proper behavior of the `.as_uri()` method. But I think it might be suitable for the next release. Thoughts?