### PR TITLE
Python 3.10 compatibility changes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -44,8 +44,8 @@ All the methods below will raise a `ValueError`_ if the path isn't absolute.
 Many of these methods can raise a `botocore.exceptions.ClientError` if `boto3`_ call fails
 (for example because the path doesn't exist).
 
-S3Path.stat()
-^^^^^^^^^^^^^
+S3Path.stat(*, follow_symlinks=True)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Returns information about this path (similarly to boto3's `ObjectSummary`_).
 For compatibility with `pathlib`_, the returned object some similar attributes like `os.stat_result`_.
@@ -64,6 +64,8 @@ The result is looked up at each call to this method:
    Traceback (most recent call last):
    ...
    io.UnsupportedOperation: StatResult do not support st_atime attribute
+
+**NOTE:** ``follow_symlinks`` option must be always set to ``True``.
 
 S3Path.exists()
 ^^^^^^^^^^^^^^^
@@ -301,8 +303,8 @@ Opens the key pointed to in bytes mode, write data to it, and close / save the k
    >>> S3Path('/test_bucket/test.txt').read_bytes()
    b'Binary file contents'
 
-S3Path.write_text(data, encoding=None, errors=None)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+S3Path.write_text(data, encoding=None, errors=None, newline=None)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Opens the key pointed to in text mode, writes data to it, and close / save the key:
 
@@ -311,6 +313,8 @@ Opens the key pointed to in text mode, writes data to it, and close / save the k
    >>> S3Path('/test_bucket/test.txt').write_text('Text file contents')
    >>> S3Path('/test_bucket/test.txt').read_text()
    'Text file contents'
+
+**NOTE:** ``newline`` option is only available on Python 3.10 and greater.
 
 S3Path.mkdir(mode=0o777, parents=False, exist_ok=False)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -453,7 +457,7 @@ Here is a list of all unsupported methods:
 
 - classmethod S3Path.cwd()
 - classmethod S3Path.home()
-- S3Path.chmod(mode)
+- S3Path.chmod(mode, *, follow_symlinks=True)
 - S3Path.expanduser()
 - S3Path.lchmod(mode)
 - S3Path.group()

--- a/s3path.py
+++ b/s3path.py
@@ -463,7 +463,7 @@ class _PathNotSupportedMixin:
         message = cls._NOT_SUPPORTED_MESSAGE.format(method=cls.home.__qualname__)
         raise NotImplementedError(message)
 
-    def chmod(self, mode):
+    def chmod(self, mode, *, follow_symlinks=True):
         """
         chmod method is unsupported on S3 service
         AWS S3 don't have this file system action concept
@@ -640,12 +640,18 @@ class S3Path(_PathNotSupportedMixin, Path, PureS3Path):
     _accessor = _s3_accessor
     __slots__ = ()
 
-    def stat(self):
+    def stat(self, *, follow_symlinks=True):
         """
         Returns information about this path (similarly to boto3's ObjectSummary).
         For compatibility with pathlib, the returned object some similar attributes like os.stat_result.
         The result is looked up at each call to this method
         """
+        if not follow_symlinks:
+            raise NotImplementedError(
+                'Setting follow_symlinks to {follow_symlinks} is '
+                'unsupported on S3 service.'.format(follow_symlinks=follow_symlinks)
+            )
+
         self._absolute_path_validation()
         if not self.key:
             return None

--- a/s3path.py
+++ b/s3path.py
@@ -632,6 +632,7 @@ class S3Path(_PathNotSupportedMixin, Path, PureS3Path):
 
     If boto3 isn't installed in your environment NotImplementedError will be raised.
     """
+    _accessor = _s3_accessor
     __slots__ = ()
 
     def stat(self):

--- a/s3path.py
+++ b/s3path.py
@@ -153,8 +153,8 @@ class _S3Accessor(_Accessor):
     def stat(self, path, *, follow_symlinks=True):
         if not follow_symlinks:
             raise NotImplementedError(
-                f'Setting follow_symlinks to {follow_symlinks} is '
-                'unsupported on S3 service.'
+                'Setting follow_symlinks to {follow_symlinks} is '
+                'unsupported on S3 service.'.format(follow_symlinks=follow_symlinks)
             )
         resource, _ = self.configuration_map.get_configuration(path)
         object_summary = resource.ObjectSummary(path.bucket, path.key)

--- a/s3path.py
+++ b/s3path.py
@@ -151,6 +151,11 @@ class _S3Accessor(_Accessor):
         self.configuration_map = _S3ConfigurationMap(default_resource_kwargs=kwargs)
 
     def stat(self, path, *, follow_symlinks=True):
+        if not follow_symlinks:
+            raise NotImplementedError(
+                f'Setting follow_symlinks to {follow_symlinks} is '
+                'unsupported on S3 service.'
+            )
         resource, _ = self.configuration_map.get_configuration(path)
         object_summary = resource.ObjectSummary(path.bucket, path.key)
         return StatResult(

--- a/s3path.py
+++ b/s3path.py
@@ -150,7 +150,7 @@ class _S3Accessor(_Accessor):
     def __init__(self, **kwargs):
         self.configuration_map = _S3ConfigurationMap(default_resource_kwargs=kwargs)
 
-    def stat(self, path):
+    def stat(self, path, *, follow_symlinks=True):
         resource, _ = self.configuration_map.get_configuration(path)
         object_summary = resource.ObjectSummary(path.bucket, path.key)
         return StatResult(

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tests/test_not_supported.py
+++ b/tests/test_not_supported.py
@@ -90,3 +90,9 @@ def test_symlink_to():
     path = S3Path('/fake-bucket/fake-key')
     with pytest.raises(NotImplementedError):
         path.symlink_to('file_name')
+
+
+def test_stat():
+    path = S3Path('/fake-bucket/fake-key')
+    with pytest.raises(NotImplementedError):
+        path.stat(follow_symlinks=False)


### PR DESCRIPTION
- Add support for CI to test on 3.10
- Explicitly set the accessor. Before 3.9 the `_accessor` was not modified but with 3.10+ `Path` now modifies the `_accessor`. So we have to explicitly override it.
- Add `follow_symlinks` argument to the `stat()` (and raise a `NotImplementError` if it is falsy)

Fixes #94.