### PR TITLE
smart-open compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     py_modules=['s3path'],
     install_requires=[
         'boto3>=1.16.35',
-        'smart-open<=5.2.1',
+        'smart-open==5.2.1',
     ],
     license='Apache 2.0',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     py_modules=['s3path'],
     install_requires=[
         'boto3>=1.16.35',
-        'smart-open',
+        'smart-open<=5.2.1',
     ],
     license='Apache 2.0',
     long_description=long_description,


### PR DESCRIPTION
With the latest version of smart-open, the compatibility is broken, it would be necessary to correct the version smart-open==5.2.1, in the setup.py