### PR TITLE
Patching pathlib to instantiate [Pure]S3Path class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,15 @@ Importing the main class:
 
    >>> from s3path import S3Path
 
+Or Importing `pathilb.Pah` it will automatically instantiate S3Path detecting `s3://` in the uri.
+
+.. code:: python
+
+   >>> from pathlib import Path
+   >>> Path("s3://pypi-proxy/")
+   S3Path('/pypi-proxy/')
+
+
 Listing "subdirectories" - s3 keys can be split like file-system with a `/` in s3path we:
 
 .. code:: python

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -629,3 +629,10 @@ def test_unlink(s3_mock):
     S3Path("/test-bucket/fake_subfolder/fake_subkey").unlink(missing_ok=True)
     S3Path("/test-bucket/fake_folder").unlink(missing_ok=True)
     S3Path("/fake-bucket/").unlink(missing_ok=True)
+
+def test_auto_instantiate_S3Path():
+    s3_path = Path("s3://bucket/directory/file.csv")
+    assert s3_path.__class__ is S3Path
+    assert s3_path.as_uri() == "s3://bucket/directory/file.csv"
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""

--- a/tests/test_pure_path_operations.py
+++ b/tests/test_pure_path_operations.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pytest
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath, PurePath
 from s3path import PureS3Path
 
 
@@ -186,3 +186,49 @@ def test_with_suffix():
     assert s3_path.with_suffix('.txt') == PureS3Path('README.txt')
     s3_path = PureS3Path('README.txt')
     assert s3_path.with_suffix('') == PureS3Path('README')
+
+def test_instantiate_empty():
+    test = PurePath()
+    assert test
+
+
+def test_auto_instantiate_PureS3Path():
+    s3_path = PurePath("s3://bucket/directory/file.csv")
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == "s3://bucket/directory/file.csv"
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+
+
+def test_auto_instantiate_PureS3Path_splited_string():
+    s3_path = PurePath("s3://", "bucket", "directory", "file.csv")
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == "s3://bucket/directory/file.csv"
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+
+
+def test_auto_instantiate_PureS3Path_splited_path():
+    s3_path = PurePath(PurePath("s3://"), PurePath("bucket"), PurePath("directory"), PurePath("file.csv"))
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == "s3://bucket/directory/file.csv"
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+
+
+def test_not_PureS3Path():
+    not_s3_path = PurePath("/", "directory", "file.csv")
+    assert not_s3_path.__class__ is not PureS3Path
+
+
+def test_not_PureS3Path_split_path():
+    not_s3_path = PurePath(PurePath("/"), PurePath("directory"), PurePath("file.csv"))
+    assert not_s3_path.__class__ is not PureS3Path
+
+
+def test_PureS3Path_from_uri():
+    s3_path = PureS3Path.from_uri("s3://bucket/directory/file.csv")
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == "s3://bucket/directory/file.csv"
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""


### PR DESCRIPTION
This proposal patch pathlib Path and PurePath in order to instantiate S3Path or PureS3Path class in case developer provide "s3://" uri. This allow to abstract the fact that we are using s3 path using PurePath/Path as factory that developer do not care that much which class is used behind the scene !