### PR TITLE
[PEP 632] Remove deprecated distutils

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ sphinx = "*"
 twine = "*"
 pytest-cov = "*"
 smart-open = "*"
+packaging = "*"
 
 [dev-packages]
 ipython = "*"

--- a/s3path.py
+++ b/s3path.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from contextlib import suppress
 from collections import namedtuple
 from platform import python_version
-from distutils.version import StrictVersion
 from io import DEFAULT_BUFFER_SIZE, UnsupportedOperation
 from pathlib import _PosixFlavour, _Accessor, PurePath, Path
 from threading import Lock
@@ -16,6 +15,7 @@ try:
     import boto3
     from botocore.exceptions import ClientError
     from botocore.docs.docstring import LazyLoadedDocstring
+    from packaging.version import Version
     import smart_open
     from s3transfer.manager import TransferManager
     ALLOWED_COPY_ARGS = TransferManager.ALLOWED_COPY_ARGS
@@ -24,6 +24,7 @@ except ImportError:
     ClientError = Exception
     LazyLoadedDocstring = None
     smart_open = None
+    Version = None
     ALLOWED_COPY_ARGS = []
 
 __version__ = '0.3.4'
@@ -784,7 +785,7 @@ class S3Path(_PathNotSupportedMixin, Path, PureS3Path):
         # to raise a `FileNotFoundError`, we need to manually check if the file exists
         # before we make the API call -- since we want to delete the file anyway,
         # we can just ignore this for now and be satisfied that the file will be removed
-        if StrictVersion(python_version()) < StrictVersion('3.8'):
+        if Version(python_version()) < Version('3.8'):
             return super().unlink()
         super().unlink(missing_ok=missing_ok)
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     py_modules=['s3path'],
     install_requires=[
         'boto3>=1.16.35',
+        'packaging',
         'smart-open',
     ],
     license='Apache 2.0',

--- a/tests/test_s3path_configuration.py
+++ b/tests/test_s3path_configuration.py
@@ -1,8 +1,8 @@
 from pathlib import Path
-from distutils.version import StrictVersion
 
 import pytest
 import smart_open
+from packaging.version import Version
 
 import boto3
 from botocore.client import Config
@@ -116,7 +116,7 @@ def test_open_method_with_custom_endpoint_url():
         resource=boto3.resource('s3', endpoint_url='http://localhost'))
 
     file_object = S3Path('/local/directory/Test.test').open('br')
-    if StrictVersion(smart_open.__version__) <= StrictVersion('3.0.0'):
+    if Version(smart_open.__version__) <= Version('3.0.0'):
         assert file_object._object.meta.client._endpoint.host == 'http://localhost'
     else:
         assert file_object._client.client._endpoint.host == 'http://localhost'


### PR DESCRIPTION
[[PEP 632]](https://peps.python.org/pep-0632/) deprecates the `distutils` module of the Python standard library. This PR removes `distutils` as a dependency of `s3path` and uses the [packaging](https://github.com/pypa/packaging) library instead.