### PR TITLE
s3path as uri-pathlib-factory uri backend plugin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,4 @@ packaging = "*"
 [dev-packages]
 ipython = "*"
 ipdb = "*"
-s3path = {editable = true, path = "."}
+s3path = {editable = true, path = ".[factory]"}

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,15 @@ From PyPI:
 
     $ pip install s3path
 
+
+Or with extra `factory` dependencies in order to use PathFactory or
+patch pathlib as factory. 
+
+.. code:: bash
+
+    $ pip install s3path[factory]
+
+
 From Conda:
 
 .. code:: bash
@@ -138,12 +147,41 @@ Or Simply reading:
    </html>
    """
 
+Using extra `factory` dependencies this lib act as s3 uri backend for 
+`uri-pathlib-factory`_ library. It gives the ability to instantiate
+S3Path, PosixPath or any other uri's backend plugin according provided uri:
+
+.. code:: python
+
+    >>> from uri_pathlib_factory import PathFactory
+    >>> PathFactory("s3://pypi-proxy/")
+    S3Path('/pypi-proxy')
+    >>> PathFactory("/pypi-proxy/")
+    PosixPath('/pypi-proxy')
+
+Or by patching pathlib module in order to use `pathlib.Path` to act as
+factory. This allows to turn existing library using pathlib interface
+to handle s3 files:
+
+    >>> from pathlib import Path
+    >>> from uri_pathlib_factory import load_pathlib_monkey_patch
+    >>> Path("s3://pypi-proxy/")
+    PosixPath('s3:/pypi-proxy')
+    >>> load_pathlib_monkey_patch()
+    >>> Path("s3://pypi-proxy/")
+    S3Path('/pypi-proxy')
+
+
 Requirements:
 =============
 
 * Python >= 3.4
 * boto3
 * smart-open
+
+Using extra `factory`
+
+* uri-pathlib-factory
 
 Further Documentation:
 ======================
@@ -156,3 +194,4 @@ Further Documentation:
 .. _Abstract pathlib interface: https://github.com/liormizr/s3path/blob/master/docs/interface.rst
 .. _Boto3 vs S3Path usage examples: https://github.com/liormizr/s3path/blob/master/docs/comparison.rst
 .. _Advanced S3Path configuration: https://github.com/liormizr/s3path/blob/master/docs/advance.rst
+.. _uri-pathlib-factory: https://pypi.org/project/uri-pathlib-factory/

--- a/s3path.py
+++ b/s3path.py
@@ -920,3 +920,12 @@ class S3DirEntry:
 
     def stat(self):
         return self._stat
+
+
+def register_uri_pathlib_s3_backend():
+    """Register s3:// pathlib implementation
+
+    return a tuple with
+    (scheme, PurePathClass, PathClass, Optional[params_adapter], )
+    """
+    return ("s3", PureS3Path, S3Path, None)

--- a/s3path.py
+++ b/s3path.py
@@ -30,6 +30,7 @@ except ImportError:
 __version__ = '0.3.4'
 __all__ = (
     'register_configuration_parameter',
+    "register_uri_pathlib_s3_backend",
     'S3Path',
     'PureS3Path',
     'StatResult',

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,14 @@ setup(
         'packaging',
         'smart-open',
     ],
+    extras_require={
+        "factory": ["uri-pathlib-factory", ]
+    },
+    entry_points = {
+        "uri_pathlib_backend": [
+            's3 = s3path:register_uri_pathlib_s3_backend'
+        ]
+    },
     license='Apache 2.0',
     long_description=long_description,
     long_description_content_type='text/x-rst',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import boto3
 import pytest
 from moto import mock_s3
 
+from uri_pathlib_factory.main import (
+    load_pathlib_monkey_patch,
+    unload_pathlib_monkey_patch,
+)
+
 from s3path import register_configuration_parameter, PureS3Path, _s3_accessor
 
 
@@ -24,3 +29,9 @@ def s3_mock(reset_configuration_cache):
     with mock_s3():
         register_configuration_parameter(PureS3Path('/'), resource=boto3.resource('s3'))
         yield
+
+
+@pytest.fixture()
+def pathlib_monkey_patch(request):
+    load_pathlib_monkey_patch()
+    request.addfinalizer(unload_pathlib_monkey_patch)

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from io import UnsupportedOperation
 from tempfile import NamedTemporaryFile
+from uri_pathlib_factory import PathFactory
 
 import boto3
 from botocore.exceptions import ClientError
@@ -629,3 +630,23 @@ def test_unlink(s3_mock):
     S3Path("/test-bucket/fake_subfolder/fake_subkey").unlink(missing_ok=True)
     S3Path("/test-bucket/fake_folder").unlink(missing_ok=True)
     S3Path("/fake-bucket/").unlink(missing_ok=True)
+
+
+
+def test_auto_instantiate_S3Path_with_pathlib_patched(pathlib_monkey_patch):
+    s3_uri = "s3://bucket/directory/file.csv"
+    s3_path = Path(s3_uri)
+    assert s3_path.__class__ is S3Path
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+    assert s3_path.as_uri() == s3_uri
+    assert str(s3_path) == "/bucket/directory/file.csv"
+
+def test_instantiate_S3Path_using_PathFactory():
+    s3_uri = "s3://bucket/directory/file.csv"
+    s3_path = PathFactory(s3_uri)
+    assert s3_path.__class__ is S3Path
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+    assert s3_path.as_uri() == s3_uri
+    assert str(s3_path) == "/bucket/directory/file.csv"

--- a/tests/test_pure_path_operations.py
+++ b/tests/test_pure_path_operations.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import pytest
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+from uri_pathlib_factory import PurePathFactory
 from s3path import PureS3Path
 
 
@@ -186,3 +187,23 @@ def test_with_suffix():
     assert s3_path.with_suffix('.txt') == PureS3Path('README.txt')
     s3_path = PureS3Path('README.txt')
     assert s3_path.with_suffix('') == PureS3Path('README')
+
+
+def test_auto_instantiate_PureS3Path(pathlib_monkey_patch):
+    s3_uri = "s3://bucket/directory/file.csv"
+    s3_path = PurePath(s3_uri)
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == s3_uri
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+    assert str(s3_path) == "/bucket/directory/file.csv"
+
+
+def test_PureS3Path_using_PurePathFactory(pathlib_monkey_patch):
+    s3_uri = "s3://bucket/directory/file.csv"
+    s3_path = PurePathFactory(s3_uri)
+    assert s3_path.__class__ is PureS3Path
+    assert s3_path.as_uri() == s3_uri
+    assert s3_path.root == "/"
+    assert s3_path.drive == ""
+    assert str(s3_path) == "/bucket/directory/file.csv"


### PR DESCRIPTION
This proposal to replace #106 

As agree on #106 I've developed https://github.com/petrus-v/uri-pathlib-factory which allow to mock pathlib and  instantiate any pathlib uri backend implementation.

This PR is about to make s3path a plugin of uri-pathlib-factory.

Dependency is optional if developer wants to keep using s3path without factory.

@liormizr I'll be happy to get your feedback and some reviews from you on uri-pathlib-factory package !