### PR TITLE
feat: Add support for python 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     license='Apache 2.0',
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    python_requires='>=3.6, >3.11',
+    python_requires='>=3.6',
     include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -33,6 +33,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        # 'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.11',
     ],
 )

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -640,3 +640,13 @@ def test_unlink(s3_mock):
     S3Path("/test-bucket/fake_subfolder/fake_subkey").unlink(missing_ok=True)
     S3Path("/test-bucket/fake_folder").unlink(missing_ok=True)
     S3Path("/fake-bucket/").unlink(missing_ok=True)
+
+def test_absolute(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    absolute_path = S3Path('/test-bucket/directory/Test.test')
+    assert absolute_path.absolute() is absolute_path
+
+    relative_path = S3Path('./Test.test')
+    with pytest.raises(ValueError):
+        relative_path.absolute()


### PR DESCRIPTION
Add support to python 3.11 by overriding the methods that were relying on `_Accessor` in cpython

Parent task: #112 