### PR TITLE
Feature: `VersionedS3Path`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,24 @@ Or Simply reading:
    </html>
    """
 
+Versioned S3 Objects:
+=====================
+
+\*New in S3Path version 0.5.0
+
+S3Path supports versioned objects for S3 buckets that have versioning enabled. ``VersionedS3Path`` is a subclass of ``S3Path`` that supports all of its features. The main difference is an additional ``version_id`` parameter in each of its constructor methods.
+
+.. code:: python
+
+   >>> from s3path import VersionedS3Path
+   >>> bucket, key, version_id = 'my-bucket', 'my-key', 'my-version-id'
+   >>> VersionedS3Path(f'/{bucket}/{key}', version_id=version_id)
+   VersionedS3Path('/my-bucket/my-key', version_id='my-version-id')
+   >>> VersionedS3Path.from_uri(f's3://{bucket}/{key}', version_id=version_id)
+   VersionedS3Path('/my-bucket/my-key', version_id='my-version-id')
+   >>> VersionedS3Path.from_bucket_key(bucket=bucket, key=key, version_id=version_id)
+   VersionedS3Path('/my-bucket/my-key', version_id='my-version-id')
+
 Requirements:
 =============
 

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -55,17 +55,21 @@ The result is looked up at each call to this method:
 
    >>> path_stat = S3Path('/pypi-proxy/boto3/index.html').stat()
    >>> path_stat
-   StatResult(size=188, last_modified=datetime.datetime(2018, 4, 4, 12, 26, 3, tzinfo=tzutc()))
+   StatResult(size=188, last_modified=datetime.datetime(2018, 4, 4, 12, 26, 3, tzinfo=tzutc()), version_id=None)
    >>> path_stat.st_size
    188
    >>> path_stat.st_mtime
    1522833963.0
+   >>> path_stat.st_version_id
    >>> path_stat.st_atime
    Traceback (most recent call last):
    ...
    io.UnsupportedOperation: StatResult do not support st_atime attribute
 
-**NOTE:** ``follow_symlinks`` option must be always set to ``True``.
+**NOTES:**
+
+* ``follow_symlinks`` option must be always set to ``True``.
+* ``S3Path.stat()`` will contain an additional ``st_version_id`` attribute that is not part of ``os.stat_result``. If the object belongs to a versioned S3 bucket, this attribute will contain the version id of the object. Otherwise, it will be ``None``.
 
 S3Path.exists()
 ^^^^^^^^^^^^^^^

--- a/s3path.py
+++ b/s3path.py
@@ -1265,12 +1265,6 @@ class PureVersionedS3Path(PureS3Path):
     def __new__(cls, *args: Union[str, PurePath], version_id: str) -> PureVersionedS3Path:
 
         self = super().__new__(cls, *args)
-
-        if not self.is_absolute():
-            raise ValueError(f"{type(self).__name__} doesn't support relative path")
-        if not self.key:
-            raise ValueError(f'{type(self).__name__} requires a key')
-
         self.version_id = version_id
         return self
 
@@ -1299,6 +1293,23 @@ class PureVersionedS3Path(PureS3Path):
 
         self = PureS3Path.from_bucket_key(bucket=bucket, key=key)
         return cls(self, version_id=version_id)
+
+    def __truediv__(self, key):
+
+        if not isinstance(key, (PureS3Path, str)):
+            return NotImplemented
+
+        key = S3Path(key) if isinstance(key, str) else key
+        return key.__rtruediv__(self)
+
+    def __rtruediv__(self, key):
+
+        if not isinstance(key, (PureS3Path, str)):
+            return NotImplemented
+
+        new_path = super().__rtruediv__(key)
+        new_path.version_id = self.version_id
+        return new_path
 
 
 class VersionedS3Path(PureVersionedS3Path, S3Path):

--- a/s3path.py
+++ b/s3path.py
@@ -6,7 +6,7 @@ s3path provides a Pythonic API to S3 by wrapping boto3 with pathlib interface
 import re
 import sys
 import fnmatch
-from typing import Any, Union, Generator, Literal, Optional
+from typing import Union, Generator, Literal, Optional
 from datetime import timedelta
 from os import stat_result
 from threading import Lock
@@ -32,6 +32,7 @@ __all__ = (
     'S3Path',
     'VersionedS3Path',
     'PureS3Path',
+    'PureVersionedS3Path',
     'StatResult',
 )
 
@@ -193,16 +194,10 @@ class _S3Accessor:
             raise NotImplementedError(
                 f'Setting follow_symlinks to {follow_symlinks} is unsupported on S3 service.')
         resource, _ = self.configuration_map.get_configuration(path)
-
-        if hasattr(path, 'version_id'):
-            object_summary = resource.ObjectVersion(path.bucket, path.key, path.version_id).get()
-        else:
-            object_summary = resource.ObjectSummary(path.bucket, path.key).get()
-
+        object_summary = resource.ObjectSummary(path.bucket, path.key)
         return StatResult(
-            size=object_summary.get('ContentLength'),
-            last_modified=object_summary.get('LastModified'),
-            version_id=object_summary.get('VersionId'),
+            size=object_summary.size,
+            last_modified=object_summary.last_modified,
         )
 
     def is_dir(self, path):
@@ -229,11 +224,7 @@ class _S3Accessor:
                 raise e
         bucket = resource.Bucket(bucket_name)
         key_name = str(path.key)
-        for object in bucket.object_versions.filter(Prefix=key_name):
-            if hasattr(path, "version_id"):
-                if object.version_id == path.version_id:
-                    return True
-                continue
+        for object in bucket.objects.filter(Prefix=key_name):
             if object.key == key_name:
                 return True
             if object.key.startswith(key_name + path._flavour.sep):
@@ -259,8 +250,6 @@ class _S3Accessor:
             'newline': newline,
         }
         transport_params = {'defer_seek': True}
-        if hasattr(path, 'version_id'):
-            transport_params.update(version_id=path.version_id)
         dummy_object = resource.Object('bucket', 'key')
         if smart_open.__version__ >= '5.1.0':
             self._smart_open_new_version_kwargs(
@@ -541,6 +530,66 @@ class _S3Accessor:
         )
 
 
+class _VersionedS3Accessor(_S3Accessor):
+
+    def stat(self, path, *, follow_symlinks=True):
+        if not follow_symlinks:
+            raise NotImplementedError(
+                f'Setting follow_symlinks to {follow_symlinks} is unsupported on S3 service.')
+        resource, _ = self.configuration_map.get_configuration(path)
+
+        object_summary = resource.ObjectVersion(path.bucket, path.key, path.version_id).get()
+
+        return StatResult(
+            size=object_summary.get('ContentLength'),
+            last_modified=object_summary.get('LastModified'),
+            version_id=object_summary.get('VersionId'),
+        )
+
+    def exists(self, path):
+        resource, _ = self.configuration_map.get_configuration(path)
+        bucket = resource.Bucket(path.bucket)
+        key = path.key
+
+        for obj in bucket.object_versions.filter(Prefix=key):
+            key_match = (obj.key == key) or obj.key.startswith(key + path._flavour.sep)
+            if key_match and (obj.version_id == path.version_id):
+                return True
+
+        return False
+
+    def open(self, path, *, mode='r', buffering=-1, encoding=None, errors=None, newline=None):
+        resource, config = self.configuration_map.get_configuration(path)
+
+        smart_open_kwargs = {
+            'uri': "s3:/" + str(path),
+            'mode': mode,
+            'buffering': buffering,
+            'encoding': encoding,
+            'errors': errors,
+            'newline': newline,
+        }
+        transport_params = {'defer_seek': True, "version_id": path.version_id}
+        dummy_object = resource.Object('bucket', 'key')
+        if smart_open.__version__ >= '5.1.0':
+            self._smart_open_new_version_kwargs(
+                dummy_object,
+                resource,
+                config,
+                transport_params,
+                smart_open_kwargs)
+        else:
+            self._smart_open_old_version_kwargs(
+                dummy_object,
+                resource,
+                config,
+                transport_params,
+                smart_open_kwargs)
+
+        file_object = smart_open.open(**smart_open_kwargs)
+        return file_object
+
+
 class _PathNotSupportedMixin:
     _NOT_SUPPORTED_MESSAGE = '{method} is unsupported on S3 service'
 
@@ -756,6 +805,7 @@ class _DeepDirCache:
 
 _s3_flavour = _S3Flavour()
 _s3_accessor = _S3Accessor()
+_versioned_s3_accessor = _VersionedS3Accessor()
 
 
 def register_configuration_parameter(
@@ -1205,68 +1255,70 @@ class S3Path(_PathNotSupportedMixin, Path, PureS3Path):
         return self._accessor.get_presigned_url(self, expire_in)
 
 
-class VersionedS3Path(S3Path):
+class PureVersionedS3Path(PureS3Path):
+    """
+    PurePath subclass for AWS S3 service Keys with Versions.
 
-    def __new__(
-        cls, *args: Union[str, Path], version_id: Optional[str] = None
-    ) -> Union[S3Path, 'VersionedS3Path']:
-        if version_id is None:
-            return S3Path(*args)
-        else:
-            return super().__new__(cls, *args)
+    S3 is not a file-system, but we can look at it like a POSIX system.
+    """
 
-    def __init__(self, *args: Union[str, Path], version_id: str) -> None:
-        """
-        __init__ instance method create a class instance from path and version id
+    def __new__(cls, *args: Union[str, PurePath], version_id: str) -> PureVersionedS3Path:
 
-        >> from s3path import VersionedS3Path
-        >> VersionedS3Path('/<bucket>/<key>', '<version_id>')
-        << VersionedS3Path('/<bucket>/<key>', '<version_id>')
-        """
+        self = super().__new__(cls, *args)
 
         if not self.is_absolute():
             raise ValueError(f"{type(self).__name__} doesn't support relative path")
         if not self.key:
             raise ValueError(f'{type(self).__name__} requires a key')
+
         self.version_id = version_id
+        return self
+
+    @classmethod
+    def from_uri(cls, uri: str, *, version_id: str) -> PureVersionedS3Path:
+        """
+        from_uri class method creates a class instance from uri and version id
+
+        >> from s3path import VersionedS3Path
+        >> VersionedS3Path.from_uri('s3://<bucket>/<key>', version_id='<version_id>')
+        << VersionedS3Path('/<bucket>/<key>', version_id='<version_id>')
+        """
+
+        self = PureS3Path.from_uri(uri)
+        return cls(self, version_id=version_id)
+
+    @classmethod
+    def from_bucket_key(cls, bucket: str, key: str, *, version_id: str) -> PureVersionedS3Path:
+        """
+        from_bucket_key class method creates a class instance from bucket, key and version id
+
+        >> from s3path import VersionedS3Path
+        >> VersionedS3Path.from_bucket_key('<bucket>', '<key>', version_id='<version_id>')
+        << VersionedS3Path('/<bucket>/<key>', version_id='<version_id>')
+        """
+
+        self = PureS3Path.from_bucket_key(bucket=bucket, key=key)
+        return cls(self, version_id=version_id)
+
+
+class VersionedS3Path(PureVersionedS3Path, S3Path):
+    """
+    S3Path subclass for AWS S3 service Keys with Versions.
+
+    >> from s3path import VersionedS3Path
+    >> VersionedS3Path('/<bucket>/<key>', version_id='<version_id>')
+    << VersionedS3Path('/<bucket>/<key>', version_id='<version_id>')
+    """
+
+    _accessor = _versioned_s3_accessor
 
     def __repr__(self) -> str:
-        return f'{type(self).__name__}("/{self.bucket}/{self.key}", version_id="{self.version_id}")'
+        return f'{type(self).__name__}("{self.as_posix()}", version_id="{self.version_id}")'
 
-    @classmethod
-    def from_uri(cls, uri: str, version_id: Optional[str] = None) -> Union[S3Path, 'VersionedS3Path']:
-        """
-        from_uri class method create a class instance from uri and version id
-
-        >> from s3path import VersionedS3Path
-        >> VersionedS3Path.from_uri('s3://<bucket>/<key>', '<version_id>')
-        << VersionedS3Path('/<bucket>/<key>', '<version_id>')
-        """
-
-        self = S3Path.from_uri(uri)
-        return cls._from_s3_path(s3_path=self, version_id=version_id)
-
-    @classmethod
-    def from_bucket_key(
-        cls, bucket: str, key: str, version_id: Optional[str] = None
-    ) -> Union[S3Path, 'VersionedS3Path']:
-        """
-        from_bucket_key class method create a class instance from bucket, key and version id
-
-        >> from s3path import VersionedS3Path
-        >> VersionedS3Path.from_bucket_key('<bucket>', '<key>', '<version_id>')
-        << VersionedS3Path('/<bucket>/<key>', '<version_id>')
-        """
-
-        self = S3Path.from_bucket_key(bucket, key)
-        return cls._from_s3_path(s3_path=self, version_id=version_id)
-
-    @classmethod
-    def _from_s3_path(cls, s3_path, version_id=None):
-        if version_id is None:
-            return s3_path
-        else:
-            return cls(s3_path, version_id=version_id)
+    def _init(self, template=None):
+        super()._init(template)
+        if template is None:
+            self._accessor = _versioned_s3_accessor
 
 
 class StatResult(namedtuple('BaseStatResult', 'size, last_modified, version_id', defaults=(None,))):

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -42,7 +42,6 @@ def test_stat(s3_mock):
     assert stat == StatResult(
         size=object_summary.size,
         last_modified=object_summary.last_modified,
-        version_id=None,
     )
 
     with NamedTemporaryFile() as local_file:
@@ -805,10 +804,6 @@ def test_versioned_bucket(s3_mock):
         S3Path(f'/{bucket}', f'{key}'),
         S3Path.from_uri(f's3://{bucket}/{key}'),
         S3Path.from_bucket_key(bucket=bucket, key=key),
-        VersionedS3Path(f'/{bucket}/{key}'),
-        VersionedS3Path(f'/{bucket}', f'{key}'),
-        VersionedS3Path.from_uri(f's3://{bucket}/{key}'),
-        VersionedS3Path.from_bucket_key(bucket=bucket, key=key),
     )
     for path in paths:
         assert not isinstance(path, VersionedS3Path)


### PR DESCRIPTION
This PR addresses issue #126 by
1. Adding a `VersionedS3Path` class to the public API
2. Adding a `st_version_id` property to `StatResult`
3. Adding automated tests for the new functionality in `tests/test_path_operations.py`
4. Adding appropriate documentation to `README.rst` and `docs/interface.rst`

## Additional notes
* `VersionedS3Path` inherits from `S3Path` but adds a `version_id` parameter to the various constructor methods. In order to follow the Liskov substitution principle, this parameter is made optional with a default value of `None`. We thought that if a user does not supply a value for this parameter, then the returned instance should be of type `S3Path` instead of `VersionedS3Path`. Hence the necessity for overriding the `__new__` constructor.
* We think that while relative paths and bucket-only paths conceptually make sense for `S3Path` objects, they do not make sense for `VersionedS3Path` objects as relative and bucket-only S3 paths have no concept of a version ID. Thus a `ValueError` is raised if a used attempts to instantiate such an object.
* We overrode the `__repr__` method as the default `__repr__` provided by `pathlib` would omit the value of the `version_id` argument, leading to a misrepresentation of the construction of the object.
* The added `st_version_id` parameter of `StatResult` has a default value of `None` and thus is fully backwards compatible with previous versions of `s3path`. In fact, we were careful to make all changes in this PR backwards compatible.
* In the new "Versioned S3 Objects:" section of `README.rst`, we added the line `\*New in S3Path version 0.5.0`. Please feel free to ask us to remove this line or to change it to whatever version this will be added to.
* Co-authored between @chnpenny and @nlangellier