### PR TITLE
Fix license-file → license_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 doc_files = LICENSE README.rst
 
 [metadata]
-license-file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
This should solve:

```
~/.conda/envs/forge/lib/python3.11/site-packages/setuptools/dist.py:498: SetuptoolsDeprecationWarning: Invalid dash-separated options
!!

        ********************************************************************************
        Usage of dash-separated 'license-file' will not be supported in future
        versions. Please use the underscore name 'license_file' instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!
  opt = self.warn_dash_deprecation(opt, section)
~/.conda/envs/forge/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!

```