### PR TITLE
Fix SyntaxWarning/DeprecationWarning

### DIFF
--- a/s3path/current_version.py
+++ b/s3path/current_version.py
@@ -759,7 +759,7 @@ class _Selector:
                 new_regex_pattern += f'{self._path._flavour.sep}*(?s:{part.replace("**", ".*")})'
                 continue
             new_regex_pattern += f'{self._path._flavour.sep}{fnmatch.translate(part)[:-2]}'
-        new_regex_pattern += '/*\Z'
+        new_regex_pattern += r'/*\Z'
 
         return re.compile(new_regex_pattern).fullmatch
 


### PR DESCRIPTION
This is a `DeprecationWarning` in Python<3.12 and a `SyntaxWarning` in Python>=3.12 since `\Z` is an invalid escape sequence. In every case, this should be made a raw string as also described in the according [change note]:

    A backslash-character pair that is not a valid escape sequence now
    generates a SyntaxWarning, instead of DeprecationWarning. For example,
    re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid
    escape sequence, use raw strings for regular expression:
    re.compile(r"\d+\.\d+")). In a future Python version, SyntaxError will
    eventually be raised, instead of SyntaxWarning.

[change note]: https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes

```shell
 ❯ docker run --rm -it python:3.11-slim python -c "a = ''; a += '/*\Z'; print(a)"
/*\Z

 ❯ docker run --rm -it python:3.11-slim python -c "a = ''; a += r'/*\Z'; print(a)"
/*\Z

 ❯ docker run --rm -it python:3.12-slim python -c "a = ''; a += '/*\Z'; print(a)"
<string>:1: SyntaxWarning: invalid escape sequence '\Z'

/*\Z

 ❯ docker run --rm -it python:3.12-slim python -c "a = ''; a += r'/*\Z'; print(a)"
/*\Z
```