### PR TITLE
Add example of buffered copy to docs

### DIFF
--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -54,7 +54,8 @@ S3Path Example:
 
 .. code:: python
 
-   >>> from s3path import S3Path, Path
+   >>> from pathlib import Path
+   >>> from s3path import S3Path
    >>> local_path = Path('/tmp/hello.txt')
    >>> S3Path('/my-bucket/hello.txt').write_text(local_path.read_text())
 
@@ -74,7 +75,8 @@ S3Path Example:
 
 .. code:: python
 
-   >>> from s3path import S3Path, Path
+   >>> from pathlib import Path
+   >>> from s3path import S3Path
    >>> local_path = Path('./my_local_image.jpg')
    >>> local_path.write_text(S3Path('/my-bucket/my_image_in_s3.jpg').read_text())
 

--- a/docs/comparison.rst
+++ b/docs/comparison.rst
@@ -59,6 +59,18 @@ S3Path Example:
    >>> local_path = Path('/tmp/hello.txt')
    >>> S3Path('/my-bucket/hello.txt').write_text(local_path.read_text())
 
+S3Path Example (buffered, to avoid loading large files into memory):
+
+.. code:: python
+
+   >>> import shutil
+   >>> from pathlib import Path
+   >>> from s3path import S3Path
+   >>> local_path = Path('/tmp/hello.txt')
+   >>> remote_path = S3Path('/my-bucket/hello.txt')
+   >>> with local_path.open('rb') as src, remote_path.open('wb') as dst:
+   >>>     shutil.copyfileobj(src, dst)
+
 boto3 Example:
 
 .. code:: python

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 import time
 from datetime import timedelta
@@ -873,3 +874,15 @@ def test_versioned_bucket(s3_mock):
     for path in paths:
         assert not isinstance(path, VersionedS3Path)
         assert path.read_bytes() == file_contents_by_version[-1]
+
+
+def test_buffered_copy(s3_mock):
+    s3 = boto3.resource('s3')
+    s3.create_bucket(Bucket='test-bucket')
+    data = b'test data' * 10_000_000
+    source_path = S3Path('/test-bucket/source')
+    source_path.write_bytes(data)
+    target_path = S3Path('/test-bucket/target')
+    with source_path.open('rb') as source, target_path.open('wb') as target:
+        shutil.copyfileobj(source, target)
+    assert target_path.read_bytes() == data


### PR DESCRIPTION
It's an extremely common use case to want to copy a file to/from/between S3 buckets. The `dst.write_text(src.read_text())` solution is simple, but not viable for large files.

Luckily, I came across [this gem](https://github.com/liormizr/s3path/issues/88#issuecomment-1551200162) by @gabrieldemarmiesse using `shutil.copyfileobj`. This works well for all combinations of `pathlib.Path` and `s3path.S3Path` as source and destination.

That comment is very difficult to discover, especially when searching for issues. Some more prominent discussions are https://github.com/liormizr/s3path/issues/98 (no solution) and https://github.com/liormizr/s3path/issues/44 (overly-complicated solution). Thus I think we should codify the solution in the documentation to make it easily discoverable.

---

I tried a few things to optimize this code:

1. There is also a function called `shutil.copyfile` that works wtih `pathlib.Path` objects. Unfortunately this function calls 
    ```python
    open(p, 'rb')
    ```
    which fails on `s3path.S3Path` objects with
    ```python
    FileNotFoundError: [Errno 2] No such file or directory: '/bucket-name/filename'
    ```
    Therefore, it's necessary to open the file handles ourselves.

3. Note that `shutil.copyfileobj` has an optional `length` argument for the buffer size. Its default value is defined as

    ```python
    COPY_BUFSIZE = 1024 * 1024 if _WINDOWS else 64 * 1024
    ```

    A few quick experiments with my setup (Linux with fiber internet) shows that the copy duration is insensitive to `length` until it drops to the ~1024 range, so I don't think we should suggest modifying this parameter.