### PR TITLE
Add Python 3.13 compatibility

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -477,7 +477,7 @@ def test_iterdir(s3_mock):
     object_summary.put(Body=b'test data')
 
     s3_path = S3Path('/test-bucket/docs')
-    assert sorted(s3_path.iterdir()) == [
+    assert sorted(s3_path.iterdir()) == sorted([
         S3Path('/test-bucket/docs/_build'),
         S3Path('/test-bucket/docs/_static'),
         S3Path('/test-bucket/docs/_templates'),
@@ -485,7 +485,7 @@ def test_iterdir(s3_mock):
         S3Path('/test-bucket/docs/index.rst'),
         S3Path('/test-bucket/docs/make.bat'),
         S3Path('/test-bucket/docs/Makefile'),
-    ]
+    ])
 
 
 def test_iterdir_on_buckets(s3_mock):

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -471,13 +471,13 @@ def test_iterdir(s3_mock):
 
     s3_path = S3Path('/test-bucket/docs')
     assert sorted(s3_path.iterdir()) == [
-        S3Path('/test-bucket/docs/Makefile'),
         S3Path('/test-bucket/docs/_build'),
         S3Path('/test-bucket/docs/_static'),
         S3Path('/test-bucket/docs/_templates'),
         S3Path('/test-bucket/docs/conf.py'),
         S3Path('/test-bucket/docs/index.rst'),
         S3Path('/test-bucket/docs/make.bat'),
+        S3Path('/test-bucket/docs/Makefile'),
     ]
 
 

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -164,10 +164,12 @@ def test_glob_nested_folders_issue_no_120(s3_mock):
     assert list(path.glob("further/*")) == [S3Path('/my-bucket/s3path-test/nested/further/test.txt')]
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
 def test_glob_old_algo(s3_mock, enable_old_glob):
     test_glob(s3_mock)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
 def test_glob_nested_folders_issue_no_115_old_algo(s3_mock, enable_old_glob):
     test_glob_nested_folders_issue_no_115(s3_mock)
 
@@ -245,14 +247,17 @@ def test_glob_nested_folders_issue_no_179(s3_mock):
         S3Path('/my-bucket/s3path/nested/further/andfurther')]
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
 def test_glob_issue_160_old_algo(s3_mock, enable_old_glob):
     test_glob_issue_160(s3_mock)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
 def test_glob_issue_160_weird_behavior_old_algo(s3_mock, enable_old_glob):
     test_glob_issue_160_weird_behavior(s3_mock)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
 def test_glob_nested_folders_issue_no_179_old_algo(s3_mock, enable_old_glob):
     test_glob_nested_folders_issue_no_179(s3_mock)
 
@@ -285,7 +290,8 @@ def test_rglob(s3_mock):
         S3Path('/test-bucket/test_pathlib.py')]
 
 
-def test_rglob_new_algo(s3_mock, enable_old_glob):
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
+def test_rglob_old_algo(s3_mock, enable_old_glob):
     test_rglob(s3_mock)
 
 
@@ -313,7 +319,8 @@ def test_accessor_scandir(s3_mock):
         S3Path('/test-bucket/test_pathlib.py')]
 
 
-def test_accessor_scandir_new_algo(s3_mock, enable_old_glob):
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason="requires python3.12 or lower")
+def test_accessor_scandir_old_algo(s3_mock, enable_old_glob):
     test_accessor_scandir(s3_mock)
 
 

--- a/tests/test_s3path_configuration.py
+++ b/tests/test_s3path_configuration.py
@@ -142,3 +142,9 @@ def test_issue_123():
     new_resource, _ = accessor.configuration_map.get_configuration(path)
     assert new_resource is s3
     assert new_resource is not old_resource
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="requires python3.13 or higher")
+def test_register_configuration_parameter_old_algo():
+    with pytest.raises(ValueError):
+        register_configuration_parameter(PureS3Path('/'), glob_new_algorithm=False)


### PR DESCRIPTION
Changes:
- `PurePath._flavour` is now known as `PurePath.parser`.
- `PurePath._load_parts()` is now gone and replaced by `PurePath._raw_path`.
- Disable old glob feature when using Python 3.13 (a lot of changes were done in official `pathlib`).