### PR TITLE
add py.typed file

### DIFF
--- a/s3path/py.typed
+++ b/s3path/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The mypy package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author='Lior Mizrahi',
     author_email='li.mizr@gmail.com',
     packages=['s3path'],
+    package_data={'s3path': ["py.typed"]},
     install_requires=[
         'boto3>=1.16.35',
         'smart-open>=5.1.0',


### PR DESCRIPTION
Add `py.typed` file so that mypy can access the type hints. See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages and https://peps.python.org/pep-0561/

closes #176 