### PR TITLE
Ensure that `Path.iterdir` is fetched lazily

### DIFF
--- a/s3path/accessor.py
+++ b/s3path/accessor.py
@@ -265,7 +265,8 @@ def scandir(path):
 
 def listdir(path):
     with scandir(path) as scandir_iter:
-        return [entry.name for entry in scandir_iter]
+        for entry in scandir_iter:
+            yield entry.name
 
 
 def open(path, *, mode='r', buffering=-1, encoding=None, errors=None, newline=None):


### PR DESCRIPTION
The previous behavior forced the full results of `Path.iterdir` to be fetched and buffered internally before any results could be returned. This causes significant delays for large bucket directories.

All other parts of call stack support streaming results lazily, so this change allows the `Path.iterdir` iterator to start returning results as soon as the first page of results is received from the S3 API.

The `accessor.listdir` function is an internal API, so this change shouldn't cause any disruption; it is only a significant performance improvement.