### PR TITLE
Improve type annotations and type correctness

### DIFF
--- a/s3path/old_versions.py
+++ b/s3path/old_versions.py
@@ -905,7 +905,7 @@ class S3Path(_PathNotSupportedMixin, Path, PureS3Path):
 
         self._absolute_path_validation()
         if not self.key:
-            return None
+            raise ValueError('Key is required for stat')
         return self._accessor.stat(self, follow_symlinks=follow_symlinks)
 
     def exists(self) -> bool:

--- a/tests/test_path_operations.py
+++ b/tests/test_path_operations.py
@@ -60,7 +60,8 @@ def test_stat(s3_mock):
         path.stat().st_atime
 
     path = S3Path('/test-bucket')
-    assert path.stat() is None
+    with pytest.raises(ValueError):
+        path.stat()
 
 
 def test_exists(s3_mock):


### PR DESCRIPTION
This adds a number of missing type annotations to the public API surface.

It also fixes the signature of several methods which allow a `follow_symlinks` parameter in Python 3.13+. This parameter is allowed in `S3Path`, but ignored.

Unfortunately, these changes are not enough for MyPy to run without errors.