### PR TITLE
Removed null encryption key vulnerability

### DIFF
--- a/s3path/old_versions.py
+++ b/s3path/old_versions.py
@@ -255,20 +255,13 @@ class _S3Accessor:
         }
         transport_params = {'defer_seek': True}
         dummy_object = resource.Object('bucket', 'key')
-        if smart_open.__version__ >= '5.1.0':
-            self._smart_open_new_version_kwargs(
-                dummy_object,
-                resource,
-                config,
-                transport_params,
-                smart_open_kwargs)
-        else:
-            self._smart_open_old_version_kwargs(
-                dummy_object,
-                resource,
-                config,
-                transport_params,
-                smart_open_kwargs)
+        self._update_smart_open_kwargs(
+            dummy_object,
+            resource,
+            config,
+            transport_params,
+            smart_open_kwargs,
+        )
 
         file_object = smart_open.open(**smart_open_kwargs)
         return file_object
@@ -447,7 +440,8 @@ class _S3Accessor:
         args=(),
         kwargs=None,
         extra_args=None,
-        allowed_extra_args=()):
+        allowed_extra_args=(),
+    ):
         kwargs = kwargs or {}
         extra_args = extra_args or {}
         if config is not None:
@@ -459,15 +453,16 @@ class _S3Accessor:
         kwargs["ExtraArgs"] = extra_args
         return boto3_method(*args, **kwargs)
 
-    def _smart_open_new_version_kwargs(
+    def _update_smart_open_kwargs(
             self,
             dummy_object,
             resource,
             config,
             transport_params,
-            smart_open_kwargs):
+            smart_open_kwargs,
+        ):
         """
-        New Smart-Open api
+        New Smart-Open (>=5.1.0) api
         Doc: https://github.com/RaRe-Technologies/smart_open/blob/develop/MIGRATING_FROM_OLDER_VERSIONS.rst
         """
         get_object_kwargs = self._update_kwargs_with_config(
@@ -483,54 +478,6 @@ class _S3Accessor:
         )
         smart_open_kwargs.update(
             compression='disable',
-            transport_params=transport_params,
-        )
-
-    def _smart_open_old_version_kwargs(
-            self,
-            dummy_object,
-            resource,
-            config,
-            transport_params,
-            smart_open_kwargs):
-        """
-        Old Smart-Open api
-        <5.0.0
-        """
-        def get_resource_kwargs():
-            # This is a good example of the complicity of boto3 and botocore
-            # resource arguments from the resource object :-/
-            # very annoying...
-            resource_kwargs = {
-                'endpoint_url': resource.meta.client.meta._endpoint_url,
-                'config': resource.meta.client._client_config,
-                'region_name': resource.meta.client._client_config.region_name,
-                'use_ssl': resource.meta.client._endpoint.host.startswith('https'),
-                'verify': resource.meta.client._endpoint.http_session._verify,
-            }
-            try:
-                credential_kwargs = {
-                    'aws_access_key_id': resource.meta.client._request_signer._credentials.access_key,
-                    'aws_secret_access_key': resource.meta.client._request_signer._credentials.secret_key,
-                    'aws_session_token': resource.meta.client._request_signer._credentials.token,
-                }
-                resource_kwargs.update(credential_kwargs)
-            except AttributeError:
-                pass
-            
-            return resource_kwargs
-
-        initiate_multipart_upload_kwargs = self._update_kwargs_with_config(
-            dummy_object.initiate_multipart_upload, config=config)
-        object_kwargs = self._update_kwargs_with_config(dummy_object.get, config=config)
-        transport_params.update(
-            multipart_upload_kwargs=initiate_multipart_upload_kwargs,
-            object_kwargs=object_kwargs,
-            resource_kwargs=get_resource_kwargs(),
-            session=boto3.DEFAULT_SESSION,
-        )
-        smart_open_kwargs.update(
-            ignore_ext=True,
             transport_params=transport_params,
         )
 
@@ -576,20 +523,13 @@ class _VersionedS3Accessor(_S3Accessor):
         }
         transport_params = {'defer_seek': True, "version_id": path.version_id}
         dummy_object = resource.Object('bucket', 'key')
-        if smart_open.__version__ >= '5.1.0':
-            self._smart_open_new_version_kwargs(
-                dummy_object,
-                resource,
-                config,
-                transport_params,
-                smart_open_kwargs)
-        else:
-            self._smart_open_old_version_kwargs(
-                dummy_object,
-                resource,
-                config,
-                transport_params,
-                smart_open_kwargs)
+        self._update_smart_open_kwargs(
+            dummy_object,
+            resource,
+            config,
+            transport_params,
+            smart_open_kwargs,
+        )
 
         file_object = smart_open.open(**smart_open_kwargs)
         return file_object
@@ -785,7 +725,8 @@ def register_configuration_parameter(
         *,
         parameters: Optional[dict] = None,
         resource: Optional[ServiceResource] = None,
-        glob_new_algorithm: Optional[bool] = None):
+        glob_new_algorithm: Optional[bool] = None,
+):
     if not isinstance(path, PureS3Path):
         raise TypeError(f'path argument have to be a {PurePath} type. got {type(path)}')
     if parameters and not isinstance(parameters, dict):


### PR DESCRIPTION
Hello! I really like this repo, managing S3 data like pathlib Path's is awesome. I'd like to use your s3path in an internal project. However, a security scan by Fortify revealed this one "vulnerability" so I wanted to contribute to its removal, so our security guys will be happy.

This is what the Fortify had to say about the offending line `access_key = secret_key = token = None`:

> 
> "Null encryption keys can compromise security in a way that is not easy to remedy.
> 
> Assigning None to encryption key variables is a bad idea because it can allow attackers to expose sensitive and encrypted information. Not only does using a null encryption key significantly reduce the protection afforded by a good encryption algorithm, but it also makes fixing the problem extremely difficult. After the offending code is in production, a software patch is required to change the null encryption key. If an account protected by the null encryption key is compromised, the owners of the system must choose between security and availability."

I will say, to get to this part in the code, you need to have python<3.12 and smart-open<5.1.0. The latter requirement is already blocked by your setup.py requirements, so if you're okay with more formally removing support for smart-open<5.1.0 (forcibly installing smart-open==5.0.0 causes 1 pytest failure on python 3.10 (`test_open_method_with_custom_endpoint_url - AssertionError: assert 'https://s3.amazonaws.com' == 'http://localhost'`) and 21 on python 3.12 (all are `TypeError: open() got an unexpected keyword argument 'compression'`)) I'm down to make an alternative PR removing this code support for <5.1.0 entirely. However, this proposed change maintains the exact same functionality as before.

I've ran the pytests with these changes and no extra errors occur asides from those inherent to smart-open==5.0.0 as mentioned. Other than with your moto tests not requiring credentials, I've otherwise tested on a bucket requiring credentials, and seen that you will get the same authentication error, whether 'aws_secret_access_key' etc. is to None (current), or not provided at all (this proposed change).