### PR TITLE
Change return type of PureS3Path class methods to Self

### DIFF
--- a/s3path/current_version.py
+++ b/s3path/current_version.py
@@ -74,7 +74,7 @@ class PureS3Path(PurePath):
             self._load_parts()
 
     @classmethod
-    def from_uri(cls, uri: str) -> PureS3Path:
+    def from_uri(cls, uri: str) -> Self:
         """
         from_uri class method create a class instance from url
 
@@ -88,7 +88,7 @@ class PureS3Path(PurePath):
         return cls(unquoted_uri[4:])
 
     @classmethod
-    def from_bucket_key(cls, bucket: str | PathLike, key: str | PathLike) -> PureS3Path:
+    def from_bucket_key(cls, bucket: str | PathLike, key: str | PathLike) -> Self:
         """
         from_bucket_key class method create a class instance from bucket, key pair's
 


### PR DESCRIPTION
Thanks for adding type hints to s3path!

I saw your comments about type hints adding to the maintenance burden, and I don't want that to be the case because the benefit of type hints are great. This is a PR to address what I believe is an error in the type hint implementation added in 0.6.3.

Closes #198 

This PR changes the return type of `PureS3Path.from_uri` and `PureS3Path.from_bucket_key` to be `Self` instead of `PureS3Path`. Both class methods return an instance of `cls` which is not necessarily a `PureS3Path` if the class method is invoked from a subclass.

```
# 0.6.3 type behavior
>> S3Path.from_uri('s3://bucket/key')
<< PureS3Path('/bucket/key')

>> PureS3Path.from_uri('s3://bucket/key')
<< PureS3Path('/bucket/key')

# Proposed type behavior
>> S3Path.from_uri('s3://bucket/key')
<< S3Path('/bucket/key')

>> PureS3Path.from_uri('s3://bucket/key')
<< PureS3Path('/bucket/key')
```

I believe this is the desired behavior because this allows construction of a concrete `S3Path` from a uri string. 

The alternative is that `PureS3Path.from_uri` should _only ever_ return a PureS3Path and not be allowed to return an `S3Path` or any other subclass of `PureS3Path`. If this is the case, instead of changing the return type hints, the implementation of the class methods should be changed to return a `PureS3Path` instead of `cls`.